### PR TITLE
Fix bs4 package name

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,11 +10,11 @@ Automatically downloads wall papers from https://alpha.wallhaven.cc/
 
 Use the package manager [pip](https://pip.pypa.io/en/stable/) to install the following packages.
 - configparser
-- BeautifulSoup
+- bs4
 - requests
 
 ```bash
-pip install configparser BeautifulSoup requests --user
+pip install configparser bs4 requests --user
 ```
 
 ## Usage


### PR DESCRIPTION
BeatifulSoup is Python 2 only package, and bs4 package is used inside the code